### PR TITLE
Tester compatibility updates

### DIFF
--- a/mooing15.py
+++ b/mooing15.py
@@ -438,7 +438,10 @@ def solve(lockedB,lockedT,free,freeB,freeT,freeF,silent=False):
     remainingP = sum(lockedB) + sum(lockedT) + lockedB[3] + lockedT[3]
     totalP = maxP - remainingP
     remainingLocked = sum(lockedB) + sum(lockedT)
+
+    unlocked_part = sum(freeB) + sum(freeT)
+    unlocked_empty = sum(free)
     
     _print(f"Progress: {totalP}/{maxP} ({remainingLocked} remaining locked gems)")
     _print("Keep in mind these results are only for the selected color")
-    return (res,starting,max,totalP,maxP,remainingLocked)
+    return (res,starting,max, totalP,maxP,remainingLocked, unlocked_part,unlocked_empty)

--- a/my_solver.py
+++ b/my_solver.py
@@ -76,7 +76,7 @@ class Solver():
 
         self._print(f"Progress: {total_progress}/{self.max_progress} ({remaining_locked} remaining locked gems)")
         self._print("Keep in mind these results are only for the selected color")
-        return (res, self.starting, self.max, total_progress, self.max_progress, remaining_locked)
+        return (res, self.starting, self.max, total_progress, self.max_progress, remaining_locked, 0, 0)
 
     def _solve_level(self, level):
         self._print(f"==Level {level + 1} Merges==")
@@ -226,5 +226,5 @@ class Solver():
         return sum(self.locked_top[from_level:]) + sum(self.free_top[from_level:])
 
 def solve(locked_bottom,locked_top,free,free_bottom,free_top,free_full,silent=False) -> Tuple[int]: #pylint: disable=unused-argument
-    solver = Solver(locked_bottom,locked_top,free,free_bottom,free_top,free_full)
+    solver = Solver(locked_bottom,locked_top,free,free_bottom,free_top,free_full,silent)
     return solver.solve()

--- a/test.py
+++ b/test.py
@@ -19,9 +19,9 @@ try:
 
         (locked_bottom, locked_top, free) = test_tuple
 
-        (res_best,starting_best,max_best,total_progress_best,max_p_best,remainingLocked_best) = bruteforce_solve(locked_bottom.copy(),locked_top.copy(),free.copy(),freeBot.copy(),freeTop.copy(),freeFull.copy(),silent=True)
-        (res_opt,starting_opt,max_opt,total_progress_opt,max_p_opt,remainingLocked_opt) = Solver(locked_bottom.copy(),locked_top.copy(),free.copy(),freeBot.copy(),freeTop.copy(),freeFull.copy(),silent=True).solve()
-        (res,starting,max_keys,total_progress,max_p,remainingLocked) = solve(locked_bottom.copy(),locked_top.copy(),free.copy(),freeBot.copy(),freeTop.copy(),freeFull.copy(),silent=True)
+        (res_best,starting_best,max_best,total_progress_best,max_p_best,remainingLocked_best,unlockedpart_best,unlockedempty_best) = bruteforce_solve(locked_bottom.copy(),locked_top.copy(),free.copy(),freeBot.copy(),freeTop.copy(),freeFull.copy(),silent=True)
+        (res_opt,starting_opt,max_opt,total_progress_opt,max_p_opt,remainingLocked_opt,unlockedpart_opt,unlockedempty_opt) = Solver(locked_bottom.copy(),locked_top.copy(),free.copy(),freeBot.copy(),freeTop.copy(),freeFull.copy(),silent=True).solve()
+        (res,starting,max_keys,total_progress,max_p,remainingLocked,unlockedpart,unlockedempty) = solve(locked_bottom.copy(),locked_top.copy(),free.copy(),freeBot.copy(),freeTop.copy(),freeFull.copy(),silent=True)
 
         if res_best > starting or res_best > max_keys:
             raise Exception('Impossible')

--- a/test_muche.py
+++ b/test_muche.py
@@ -31,11 +31,11 @@ def get_solvers() -> List[types.FunctionType]:
 class TestCaseType(Flag):
     NONE = 0
     SKIP = 1
-    DEV = 2  # instead of running the rest and comparing the results, run all imported solvers with the input to find out the results
+    DEV = 2  # instead of running the test and comparing the results, run all imported solvers with the input to find out the results
     FOCUS = 4  # to be able to mark test(s) selectively and run only it/them
     BASE = 8  # manually crafted tests focusing on some feature
     FULL = 16  # full boards as gotten from the game
-    PERF = 32  # performance tests, usually tests containing lots of gems leading to lost of possibilities, thus longer running times
+    PERF = 32  # performance tests, usually tests containing lots of gems leading to lots of possibilities, thus longer running times
     ALL = DEV | FOCUS | BASE | FULL | PERF
 
 run_testcases_and = TestCaseType.ALL
@@ -59,7 +59,7 @@ class TestCase():
     FAIL = "\033[31mfailed\033[0m test"
     IMPR = "\033[31mimproved\033[0m test"
     SKIP = "skipped test"
-    DONE = "done test"
+    DONE = "\033[35mdone test\033[0m"
 
     def __init__(
             self, name:str, tctype:TestCaseType,
@@ -119,7 +119,7 @@ class TestCase():
             return rr.try_impr()
         return rr
 
-    def _run_normal(self) -> str:
+    def _run_normal(self) -> Tuple[str, int, int, int, int]:
         rr = RunResult.PASS
         rrstr: List[str] = []
         tStart = timer()
@@ -150,7 +150,7 @@ class TestCase():
             rrstr.insert(0, " -")
         return (f"{status} '{self.name}' in {tEnd-tStart:.3f}s{' '.join(rrstr)}", 0, p, i, f)
 
-    def run(self, mask_and: TestCaseType, mask_or: TestCaseType) -> str:
+    def run(self, mask_and: TestCaseType, mask_or: TestCaseType) -> Tuple[str, int, int, int, int]:
         if (self.tctype & mask_and != self.tctype) or (self.tctype & mask_or == TestCaseType.NONE):
             return (self._run_skip(), 1, 0, 0, 0)
         if self.is_dev():
@@ -653,6 +653,186 @@ testcases: List[TestCase] = [
         locked_bottom=(1,3,2,1), locked_top=(2,2,2,1), free=(7,0,4,0),
         free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
         keys=19, max_keys=21, progress=16, potential_progress=16,
+        unlocked_part = 0, unlocked_empty = 0
+    ),
+    TestCase(name="tc27 perf", tctype=TestCaseType.FULL | TestCaseType.PERF,
+        locked_bottom=(0,1,2,2), locked_top=(3,3,1,1), free=(3,1,4,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=15, max_keys=15, progress=16, potential_progress=16,
+        unlocked_part = 1, unlocked_empty = 0
+    ),
+    TestCase(name="tc28", tctype=TestCaseType.FULL,
+        locked_bottom=(0,1,3,0), locked_top=(1,0,0,2), free=(4,0,1,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=6, max_keys=9, progress=8, potential_progress=9,
+        unlocked_part = 1, unlocked_empty = 1
+    ),
+    TestCase(name="tc29", tctype=TestCaseType.FULL,
+        locked_bottom=(1,2,2,2), locked_top=(3,1,0,1), free=(2,1,0,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=7, max_keys=15, progress=13, potential_progress=15,
+        unlocked_part = 0, unlocked_empty = 0
+    ),
+    TestCase(name="tc30", tctype=TestCaseType.FULL,
+        locked_bottom=(2,0,2,1), locked_top=(2,1,1,2), free=(4,0,1,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=9, max_keys=15, progress=14, potential_progress=14,
+        unlocked_part = 1, unlocked_empty = 0
+    ),
+    TestCase(name="tc31", tctype=TestCaseType.FULL,
+        locked_bottom=(3,1,3,1), locked_top=(2,1,0,1), free=(6,1,0,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=10, max_keys=12, progress=14, potential_progress=14,
+        unlocked_part = 0, unlocked_empty = 1
+    ),
+    TestCase(name="tc32", tctype=TestCaseType.FULL,
+        locked_bottom=(1,1,1,0), locked_top=(3,1,1,1), free=(4,0,0,1),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=7, max_keys=9, progress=10, potential_progress=10,
+        unlocked_part = 1, unlocked_empty = 0
+    ),
+    TestCase(name="tc33", tctype=TestCaseType.FULL,
+        locked_bottom=(0,2,2,1), locked_top=(3,2,0,0), free=(4,2,1,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=10, max_keys=15, progress=11, potential_progress=11,
+        unlocked_part = 1, unlocked_empty = 1
+    ),
+    TestCase(name="tc34", tctype=TestCaseType.FULL,
+        locked_bottom=(1,2,0,1), locked_top=(1,4,3,0), free=(4,1,0,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=10, max_keys=12, progress=11, potential_progress=13,
+        unlocked_part = 0, unlocked_empty = 0
+    ),
+    TestCase(name="tc35", tctype=TestCaseType.FULL,
+        locked_bottom=(2,0,2,3), locked_top=(1,1,0,1), free=(1,1,2,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=6, max_keys=9, progress=12, potential_progress=14,
+        unlocked_part = 1, unlocked_empty = 1
+    ),
+    TestCase(name="tc36", tctype=TestCaseType.FULL,
+        locked_bottom=(1,0,1,0), locked_top=(1,2,1,3), free=(1,0,0,1),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=3, max_keys=6, progress=9, potential_progress=12,
+        unlocked_part = 1, unlocked_empty = 0
+    ),
+    TestCase(name="tc37 perf", tctype=TestCaseType.FULL | TestCaseType.PERF,
+        locked_bottom=(1,2,5,3), locked_top=(1,2,4,0), free=(3,2,2,1),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=18, max_keys=21, progress=18, potential_progress=21,
+        unlocked_part = 1, unlocked_empty = 1
+    ),
+    TestCase(name="tc38", tctype=TestCaseType.FULL,
+        locked_bottom=(1,1,1,0), locked_top=(1,1,0,0), free=(2,3,1,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=6, max_keys=6, progress=5, potential_progress=5,
+        unlocked_part = 1, unlocked_empty = 2
+    ),
+    TestCase(name="tc39", tctype=TestCaseType.FULL,
+        locked_bottom=(0,0,0,0), locked_top=(3,0,0,1), free=(1,1,1,1),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=0, max_keys=0, progress=3, potential_progress=5,
+        unlocked_part = 2, unlocked_empty = 2
+    ),
+    TestCase(name="tc40", tctype=TestCaseType.FULL,
+        locked_bottom=(0,2,0,1), locked_top=(4,3,5,0), free=(2,2,4,1),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=9, max_keys=9, progress=13, potential_progress=16,
+        unlocked_part = 4, unlocked_empty = 2
+    ),
+    TestCase(name="tc41", tctype=TestCaseType.FULL,
+        locked_bottom=(1,3,1,2), locked_top=(2,2,1,1), free=(3,0,0,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=7, max_keys=18, progress=14, potential_progress=16,
+        unlocked_part = 0, unlocked_empty = 0
+    ),
+    TestCase(name="tc42", tctype=TestCaseType.FULL,
+        locked_bottom=(3,0,5,0), locked_top=(2,2,2,0), free=(0,2,0,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=6, max_keys=18, progress=4, potential_progress=14,
+        unlocked_part = 0, unlocked_empty = 0
+    ),
+    TestCase(name="tc43 perf", tctype=TestCaseType.FULL | TestCaseType.PERF,
+        locked_bottom=(2,1,1,2), locked_top=(1,1,1,1), free=(4,3,2,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=12, max_keys=12, progress=13, potential_progress=13,
+        unlocked_part = 0, unlocked_empty = 1
+    ),
+    TestCase(name="tc44", tctype=TestCaseType.FULL,
+        locked_bottom=(1,1,0,0), locked_top=(4,2,0,0), free=(2,1,2,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=6, max_keys=6, progress=5, potential_progress=8,
+        unlocked_part = 1, unlocked_empty = 0
+    ),
+    TestCase(name="tc45", tctype=TestCaseType.FULL,
+        locked_bottom=(0,0,0,2), locked_top=(1,0,0,0), free=(3,0,2,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=3, max_keys=3, progress=5, potential_progress=5,
+        unlocked_part = 0, unlocked_empty = 1
+    ),
+    TestCase(name="tc46", tctype=TestCaseType.FULL,
+        locked_bottom=(2,1,1,0), locked_top=(0,3,0,0), free=(4,2,1,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=9, max_keys=9, progress=7, potential_progress=7,
+        unlocked_part = 1, unlocked_empty = 0
+    ),
+    TestCase(name="tc47 perf", tctype=TestCaseType.FULL | TestCaseType.PERF,
+        locked_bottom=(1,6,2,4), locked_top=(1,2,3,3), free=(6,6,0,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=21, max_keys=27, progress=29, potential_progress=29,
+        unlocked_part = 0, unlocked_empty = 0
+    ),
+    TestCase(name="tc48", tctype=TestCaseType.FULL,
+        locked_bottom=(2,0,1,0), locked_top=(1,0,1,1), free=(4,2,0,1),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=6, max_keys=9, progress=7, potential_progress=7,
+        unlocked_part = 2, unlocked_empty = 1
+    ),
+    TestCase(name="tc49", tctype=TestCaseType.FULL,
+        locked_bottom=(4,2,5,1), locked_top=(1,1,1,1), free=(1,2,0,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=9, max_keys=12, progress=11, potential_progress=18,
+        unlocked_part = 0, unlocked_empty = 0
+    ),
+    TestCase(name="tc50", tctype=TestCaseType.FULL,
+        locked_bottom=(1,2,0,0), locked_top=(2,1,2,2), free=(5,1,0,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=9, max_keys=9, progress=12, potential_progress=12,
+        unlocked_part = 0, unlocked_empty = 0
+    ),
+    TestCase(name="tc51", tctype=TestCaseType.FULL,
+        locked_bottom=(3,2,0,1), locked_top=(1,1,1,2), free=(4,0,0,1),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=9, max_keys=15, progress=14, potential_progress=14,
+        unlocked_part = 1, unlocked_empty = 0
+    ),
+    TestCase(name="tc52", tctype=TestCaseType.FULL,
+        locked_bottom=(1,3,1,0), locked_top=(4,0,1,0), free=(2,1,1,1),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=9, max_keys=15, progress=7, potential_progress=10,
+        unlocked_part = 0, unlocked_empty = 1
+    ),
+    TestCase(name="tc53", tctype=TestCaseType.FULL,
+        locked_bottom=(0,0,3,2), locked_top=(2,1,2,1), free=(2,1,2,1),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=12, max_keys=15, progress=13, potential_progress=14,
+        unlocked_part = 1, unlocked_empty = 0
+    ),
+    TestCase(name="tc54", tctype=TestCaseType.FULL,
+        locked_bottom=(2,1,1,0), locked_top=(0,1,1,2), free=(2,0,1,1),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=7, max_keys=12, progress=10, potential_progress=10,
+        unlocked_part = 1, unlocked_empty = 0
+    ),
+    TestCase(name="tc55", tctype=TestCaseType.FULL,
+        locked_bottom=(1,2,3,1), locked_top=(2,1,1,1), free=(4,0,1,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=12, max_keys=15, progress=14, potential_progress=14,
+        unlocked_part = 0, unlocked_empty = 1
+    ),
+    TestCase(name="tc56", tctype=TestCaseType.FULL,
+        locked_bottom=(2,2,2,1), locked_top=(3,1,0,1), free=(5,0,2,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=12, max_keys=15, progress=14, potential_progress=14,
         unlocked_part = 0, unlocked_empty = 0
     ),
 

--- a/test_muche.py
+++ b/test_muche.py
@@ -403,6 +403,32 @@ testcases: List[TestCase] = [
         keys=3, max_keys=3, progress=6, potential_progress=6,
         unlocked_part = 2, unlocked_empty = 0
     ),
+    TestCase(name="unmerged top is better than unmerged empty", tctype=TestCaseType.BASE,
+        locked_bottom=(0,0,0,1), locked_top=(1,0,0,1), free=(1,2,1,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=3, max_keys=3, progress=5, potential_progress=5,
+        unlocked_part = 1, unlocked_empty = 0
+    ),
+    TestCase(name="unmerged bot is better than unmerged empty", tctype=TestCaseType.BASE,
+        locked_bottom=(1,0,0,1), locked_top=(0,0,0,1), free=(1,2,1,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=3, max_keys=3, progress=5, potential_progress=5,
+        unlocked_part = 1, unlocked_empty = 0
+    ),
+    # numbers technically based on clear board reward (1 key per 10 empty gems, 1 key per 4 gems with a key part)
+    # but still it's rare, circumstential and debatable
+    TestCase(name="one unmerged top is better than two unmerged empties", tctype=TestCaseType.BASE,
+        locked_bottom=(0,0,0,1), locked_top=(1,0,0,1), free=(3,1,1,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=3, max_keys=3, progress=5, potential_progress=5,
+        unlocked_part = 1, unlocked_empty = 0
+    ),
+    TestCase(name="one unmerged bot is better than two unmerged empties", tctype=TestCaseType.BASE,
+        locked_bottom=(1,0,0,1), locked_top=(0,0,0,1), free=(3,1,1,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=3, max_keys=3, progress=5, potential_progress=5,
+        unlocked_part = 1, unlocked_empty = 0
+    ),
 
 
     # boards from comments at https://www.mooingcatguides.com/event-guides/2023-anniversary-event-guide#comments
@@ -479,7 +505,7 @@ testcases: List[TestCase] = [
         locked_bottom=(2,0,0,2), locked_top=(0,0,1,1), free=(4,0,0,2),
         free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
         keys=6, max_keys=6, progress=9, potential_progress=9,
-        unlocked_part = 1, unlocked_empty = 2
+        unlocked_part = 2, unlocked_empty = 0
     ),
     TestCase(name="tc4", tctype=TestCaseType.FULL,
         locked_bottom=(0,1,0,0), locked_top=(0,3,1,1), free=(3,1,1,2),

--- a/test_muche.py
+++ b/test_muche.py
@@ -488,6 +488,12 @@ testcases: List[TestCase] = [
         keys=9, max_keys=15, progress=11, potential_progress=11,
         unlocked_part = 1, unlocked_empty = 1
     ),
+    TestCase(name="comment-6155079334 by MarkusS", tctype=TestCaseType.FULL,
+        locked_bottom=(1,0,0,2), locked_top=(1,3,2,0), free=(4,0,0,0),
+        free_bottom=(0,0,0,0), free_top=(0,0,0,0), free_full=(0,0,0,0),
+        keys=7, max_keys=9, progress=11, potential_progress=11,
+        unlocked_part = 0, unlocked_empty = 0
+    ),
 
 
     # some of my boards

--- a/test_muche.py
+++ b/test_muche.py
@@ -5,20 +5,20 @@ from timeit import default_timer as timer
 from typing import Tuple, List
 
 # active solver
-# from solver_v31 import solve
 from solver import solve
 #from mooing15 import solve
+#from my_solver import solve
+#from solver_v31 import solve
 
 # reference solver by MooingCat
 import mooing15 as solver_mooing15
 # other reference solvers used to establish best results in dev mode
-#import solver_coen_v3
-#import solver_coen_v3b
-#import solver_coen_v3c
-#import solver_coen_v3d
+#import my_solver as solver_my
+import solver as solver_optimized_bruteforce
+#import solver_v31
 
 
-version = "v1.0"
+version = "v1.1"
 
 
 def get_solvers() -> List[types.FunctionType]:
@@ -95,7 +95,7 @@ class TestCase():
 
     def _run_dev(self) -> str:
         for solver in get_solvers():
-            print(f"\n\tRunning test '{self.name}' with solver {solver.__module__}:")
+            print(f"\n\t\033[35mRunning test '{self.name}' with solver {solver.__module__}:\033[0m")
             tStart = timer()
             # MooingCat's solver expects lists and modifies them, so need to copy & transform the inputs
             try:

--- a/test_muche.py
+++ b/test_muche.py
@@ -7,9 +7,10 @@ from typing import Tuple, List
 # active solver
 # from solver_v31 import solve
 from solver import solve
+#from mooing15 import solve
 
 # reference solver by MooingCat
-# import solver_v15
+import mooing15 as solver_mooing15
 # other reference solvers used to establish best results in dev mode
 #import solver_coen_v3
 #import solver_coen_v3b
@@ -123,7 +124,8 @@ class TestCase():
         rrstr: List[str] = []
         tStart = timer()
         try:
-            result = solve(self.locked_bottom, self.locked_top, self.free, self.free_bottom, self.free_top, self.free_full, True)
+            # MooingCat's solver expects lists and modifies them, so need to copy & transform the inputs
+            result = solve(list(self.locked_bottom), list(self.locked_top), list(self.free), list(self.free_bottom), list(self.free_top), list(self.free_full), True)
             result_keys = result[0]
             result_max_keys = result[2]
             result_progress = result[3]


### PR DESCRIPTION
I've made some tester compatibility updates for all solvers present, so they can easily be ran by it (depending on which one is uncommented).

For _my_solver_, I did not bother to compute _unlocked_part_ and _unlocked_empty_ results, just made it return zeroes, so it can run.

As for _unlocked_part_ and _unlocked_empty_ tests & related results, the current biases & results are somewhat consistent, but I don't think it's worth investing more energy into optimizing them further. Should any test fail due to them, it can be safely ignored. In the short term during development their comparison could even be disabled by commenting their respective lines.